### PR TITLE
ci: renovate [SUB-9999]

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -36,5 +36,5 @@ jobs:
           RENOVATE_USERNAME: renovate-release
           RENOVATE_NPM_JSQ__972451838497_D_CODEARTIFACT_US_WEST_2_AMAZONAWS_COM_NPM_SHARED_USERNAME: "aws"
           RENOVATE_NPM_JSQ__972451838497_D_CODEARTIFACT_US_WEST_2_AMAZONAWS_COM_NPM_SHARED_PASSWORD: ${{ needs.codeartifact-token.outputs.codeartifact-token }}
-          LOG_LEVEL: debug
           RENOVATE_PLATFORM: github
+          LOG_LEVEL: debug


### PR DESCRIPTION

This pull request includes a minor change to the `.github/workflows/renovate.yaml` file. The change involves reordering the `LOG_LEVEL` environment variable assignment within the `jobs:` section.

* [`.github/workflows/renovate.yaml`](diffhunk://#diff-f87681f1c7db60655a75838d0610544d4b75e26c6909a97b97f5ec4aa323c7aaL39-R40): Moved the `LOG_LEVEL: debug` line to a different position within the `jobs:` section.